### PR TITLE
Remove ssh commands in build_image.py

### DIFF
--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -1,5 +1,3 @@
-import time
-import os
 import boto3
 import utils
 import config
@@ -14,10 +12,6 @@ instances = ec2.create_instances(
     MinCount=1,
     MaxCount=1,
     InstanceType=config.INSTANCE_TYPE,
-    KeyName=config.SSH_KEY,
-    SecurityGroups=[
-        config.SECURITY_GROUP,
-    ],
     UserData=config.USER_DATA
 )
 print('   Instance created. ID: {}'.format(instances[0].id))
@@ -46,24 +40,6 @@ if HEALTH == utils.STATUS_OK:
 else:
     print('   Timeout waiting for health check')
     utils.terminate_instance_and_exit(instance)
-
-# Execute deploy script via SSH
-
-commands = [
-    'curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | sudo bash -s {0}'.format(
-        config.MEILI_CLOUD_SCRIPTS_VERSION_TAG),
-]
-
-for cmd in commands:
-    SSH_COMMAND = 'ssh {user}@{host} -o StrictHostKeyChecking=no -i {ssh_key_path} "{cmd}"'.format(
-        user=config.SSH_USER,
-        host=instance.public_ip_address,
-        ssh_key_path=config.SSH_KEY_PEM_FILE,
-        cmd=cmd,
-    )
-    print('EXECUTE COMMAND:', SSH_COMMAND)
-    os.system(SSH_COMMAND)
-    time.sleep(5)
 
 # Create AMI Image
 

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -12,6 +12,9 @@ instances = ec2.create_instances(
     MinCount=1,
     MaxCount=1,
     InstanceType=config.INSTANCE_TYPE,
+    SecurityGroups=[
+        config.SECURITY_GROUP,
+    ],
     UserData=config.USER_DATA
 )
 print('   Instance created. ID: {}'.format(instances[0].id))

--- a/tools/config.py
+++ b/tools/config.py
@@ -22,7 +22,7 @@ SECURITY_GROUP = 'MarketplaceSecurityGroup'
 BASE_OS_NAME = 'Debian-10.3'
 DEBIAN_BASE_IMAGE_ID = 'ami-003f19e0e687de1cd'
 USER_DATA = requests.get(
-    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/aws/cloud-config.yaml'
+    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/providers/aws/cloud-config.yaml'
     .format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)
 ).text
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,4 +1,6 @@
+from os.path import expanduser
 from datetime import datetime
+import requests
 
 # Update with the MeiliSearch version TAG you want to build the AMI with
 
@@ -11,6 +13,10 @@ PUBLISH_IMAGE_ID = 'ami-0fbe1008176402eae'
 # Update with the AMI name that you want to unpublish/delete worldwide
 
 DELETE_IMAGE_NAME = 'MeiliSearch-v0.19.0-Debian-10.3'
+
+# Update with your own Securityt Group and Key Pair name / file
+
+SECURITY_GROUP = 'MarketplaceSecurityGroup'
 
 # Setup environment and settings
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,6 +1,4 @@
-from os.path import expanduser
 from datetime import datetime
-import requests
 
 # Update with the MeiliSearch version TAG you want to build the AMI with
 
@@ -14,22 +12,11 @@ PUBLISH_IMAGE_ID = 'ami-0fbe1008176402eae'
 
 DELETE_IMAGE_NAME = 'MeiliSearch-v0.19.0-Debian-10.3'
 
-# Update with your own Securityt Group and Key Pair name / file
-
-SECURITY_GROUP = 'MarketplaceSecurityGroup'
-SSH_KEY = 'MarketplaceKeyPair-NVirginia'
-SSH_KEY_PEM_FILE = expanduser(
-    '~') + '/.aws/KeyPairs/MarketplaceKeyPair-NVirginia.pem'
-
 # Setup environment and settings
 
-PROVIDER_NAME='aws'
-BASE_OS_NAME='Debian-10.3'
-DEBIAN_BASE_IMAGE_ID='ami-003f19e0e687de1cd'
-USER_DATA = requests.get(
-    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/cloud-config.yaml'
-    .format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)
-).text.replace("unknown_provider", PROVIDER_NAME)
+PROVIDER_NAME = 'aws'
+BASE_OS_NAME = 'Debian-10.3'
+DEBIAN_BASE_IMAGE_ID = 'ami-003f19e0e687de1cd'
 
 SNAPSHOT_NAME = 'MeiliSearch-{}-{}'.format(
     MEILI_CLOUD_SCRIPTS_VERSION_TAG, BASE_OS_NAME)
@@ -64,3 +51,91 @@ AWS_REGIONS = [
     'me-south-1',
     'sa-east-1',
 ]
+
+# Cloud-init
+
+USER_DATA = """
+#cloud-config
+
+package_update: true
+
+package_upgrade: true
+
+users:
+  - default
+  - name: meilisearch
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    ssh_import_id: root
+    lock_passwd: True
+    shell: /bin/bash
+    groups: [sudo]
+  - name: root
+    shell: /bin/bash
+
+packages:  
+  - git
+  - curl
+  - ufw
+  - gcc
+  - make
+  - nginx
+  - certbot
+  - python-certbot-nginx
+
+write_files:
+  - path: /etc/systemd/system/meilisearch.service
+    content: |
+      [Unit]
+      Description=MeiliSearch
+      After=systemd-user-sessions.service
+
+      [Service]
+      Type=simple
+      ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch/data.ms --env development
+      Environment='MEILI_SERVER_PROVIDER=digitalocean'
+
+      [Install]
+      WantedBy=default.target
+
+  - path: /etc/nginx/sites-enabled/meilisearch
+    content: |
+      server {{
+          listen 80 default_server;
+          listen [::]:80 default_server;
+
+          server_name _;
+
+          location / {{
+              proxy_pass  http://127.0.0.1:7700;
+          }}
+
+          client_max_body_size 100M;
+      }}
+  
+  - path: /etc/nginx/sites-enabled/default
+    content: |
+      # Empty file
+
+  - path: /etc/profile.d/00-aliases.sh
+    content: |
+      alias meilisearch-setup='sudo sh /var/opt/meilisearch/scripts/first-login/000-set-meili-env.sh'
+
+  - path: /etc/profile.d/01-auto-run.sh
+    content: |
+      meilisearch-setup
+
+runcmd:
+  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/MeiliSearch/releases/download/{0}/meilisearch-linux-amd64
+  - chmod 755 /usr/bin/meilisearch
+  - systemctl enable meilisearch.service
+  - ufw --force enable
+  - ufw allow 'Nginx Full'
+  - ufw allow 'OpenSSH'
+  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | sudo bash -s {0}
+
+power_state:
+  mode: reboot
+  message: Bye Bye
+  timeout: 10
+  condition: True
+""".format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import requests
 
 # Update with the MeiliSearch version TAG you want to build the AMI with
 
@@ -18,9 +19,12 @@ SECURITY_GROUP = 'MarketplaceSecurityGroup'
 
 # Setup environment and settings
 
-PROVIDER_NAME = 'aws'
 BASE_OS_NAME = 'Debian-10.3'
 DEBIAN_BASE_IMAGE_ID = 'ami-003f19e0e687de1cd'
+USER_DATA = requests.get(
+    'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{}/scripts/aws/cloud-config.yaml'
+    .format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)
+).text
 
 SNAPSHOT_NAME = 'MeiliSearch-{}-{}'.format(
     MEILI_CLOUD_SCRIPTS_VERSION_TAG, BASE_OS_NAME)
@@ -55,91 +59,3 @@ AWS_REGIONS = [
     'me-south-1',
     'sa-east-1',
 ]
-
-# Cloud-init
-
-USER_DATA = """
-#cloud-config
-
-package_update: true
-
-package_upgrade: true
-
-users:
-  - default
-  - name: meilisearch
-    sudo: ['ALL=(ALL) NOPASSWD:ALL']
-    ssh_import_id: root
-    lock_passwd: True
-    shell: /bin/bash
-    groups: [sudo]
-  - name: root
-    shell: /bin/bash
-
-packages:  
-  - git
-  - curl
-  - ufw
-  - gcc
-  - make
-  - nginx
-  - certbot
-  - python-certbot-nginx
-
-write_files:
-  - path: /etc/systemd/system/meilisearch.service
-    content: |
-      [Unit]
-      Description=MeiliSearch
-      After=systemd-user-sessions.service
-
-      [Service]
-      Type=simple
-      ExecStart=/usr/bin/meilisearch --db-path /var/lib/meilisearch/data.ms --env development
-      Environment='MEILI_SERVER_PROVIDER=digitalocean'
-
-      [Install]
-      WantedBy=default.target
-
-  - path: /etc/nginx/sites-enabled/meilisearch
-    content: |
-      server {{
-          listen 80 default_server;
-          listen [::]:80 default_server;
-
-          server_name _;
-
-          location / {{
-              proxy_pass  http://127.0.0.1:7700;
-          }}
-
-          client_max_body_size 100M;
-      }}
-  
-  - path: /etc/nginx/sites-enabled/default
-    content: |
-      # Empty file
-
-  - path: /etc/profile.d/00-aliases.sh
-    content: |
-      alias meilisearch-setup='sudo sh /var/opt/meilisearch/scripts/first-login/000-set-meili-env.sh'
-
-  - path: /etc/profile.d/01-auto-run.sh
-    content: |
-      meilisearch-setup
-
-runcmd:
-  - wget --directory-prefix=/usr/bin/ -O /usr/bin/meilisearch https://github.com/meilisearch/MeiliSearch/releases/download/{0}/meilisearch-linux-amd64
-  - chmod 755 /usr/bin/meilisearch
-  - systemctl enable meilisearch.service
-  - ufw --force enable
-  - ufw allow 'Nginx Full'
-  - ufw allow 'OpenSSH'
-  - curl https://raw.githubusercontent.com/meilisearch/cloud-scripts/{0}/scripts/deploy-meilisearch.sh | sudo bash -s {0}
-
-power_state:
-  mode: reboot
-  message: Bye Bye
-  timeout: 10
-  condition: True
-""".format(MEILI_CLOUD_SCRIPTS_VERSION_TAG)

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,6 +1,4 @@
-from os.path import expanduser
 from datetime import datetime
-import requests
 
 # Update with the MeiliSearch version TAG you want to build the AMI with
 


### PR DESCRIPTION
closes #31

This is the first draft for the removal of the ssh commands.
See #31

It aims to :
- Simplify the whole process
- Have the same structure in all the meilisearch-cloud repositories
- Easier implementation of the future tests/CI
- Make the maintenance easier

What has been done :
- Remove the ssh commands launched after the EC2 instance creation
- Remove SECURITY_GROUP, SSH_KEY, SSH_KEY_PEM_FILE
- cloud-config.yaml is now unique for each repository (not in cloud-scripts anymore) and directly put in USER_DATA

To do :
- @eskombro Can we delete the variable SECURITY_GROUP?
- Test
- Update contributing
- @eskombro would you prefer the cloud-config.yaml to be an independant file instead of a variable USER_DATA in config.py?