### PR TITLE
Create a script to test the image built and add the full process to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      AWS_DEFAULT_REGION: us-east-1
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,9 +17,9 @@ jobs:
     name: build-image-test
     runs-on: ubuntu-latest
     env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      AWS_DEFAULT_REGION: us-east-1
+      aws_access_key_id: ${{secrets.AWS_ACCESS_KEY_ID}}
+      aws_secret_access_key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      aws_default_region: us-east-1
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,9 @@ jobs:
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     name: build-image-test
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY_ID}}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -24,12 +27,6 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: pip3 install -r requirements.txt
-    - name: Configure AWS credentials from Test account
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
     - name: Set image name as env variable
       run: echo "IMAGE_NAME=meilisearch_aws_ci_test_$(date +'%d-%m-%Y-%H-%M-%S')" >> $GITHUB_ENV
     - name: Build image

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,33 @@ on:
       - main
 
 jobs:
+  tests:
+    # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
+    # Will still run for each push to bump-meilisearch-v*
+    if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
+    name: build-image-test
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: pip3 install -r requirements.txt
+    - name: Set image name as env variable
+      run: echo "IMAGE_NAME=meilisearch_aws_ci_test_$(date +'%d-%m-%Y-%H-%M-%S')" >> $GITHUB_ENV
+    - name: Build image
+      run: python3 tools/build_image.py $IMAGE_NAME
+    - name: Test image
+      run: python3 tools/test_image.py $IMAGE_NAME
+    - name: Clean image
+      if: ${{ always() }}
+      run: python3 tools/destroy_image.py $IMAGE_NAME
+
   pylint:
     name: pylint
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,8 @@ jobs:
     name: build-image-test
     runs-on: ubuntu-latest
     env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY_ID}}
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,6 @@ jobs:
     if: github.event_name != 'pull_request' || !startsWith(github.base_ref, 'bump-meilisearch-v')
     name: build-image-test
     runs-on: ubuntu-latest
-    env:
-      aws_access_key_id: ${{secrets.AWS_ACCESS_KEY_ID}}
-      aws_secret_access_key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      aws_default_region: us-east-1
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python 3.7
@@ -28,6 +24,12 @@ jobs:
         python-version: 3.7
     - name: Install dependencies
       run: pip3 install -r requirements.txt
+    - name: Configure AWS credentials from Test account
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
     - name: Set image name as env variable
       run: echo "IMAGE_NAME=meilisearch_aws_ci_test_$(date +'%d-%m-%Y-%H-%M-%S')" >> $GITHUB_ENV
     - name: Build image

--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -50,8 +50,9 @@ else:
 print('Waiting for Version check')
 try:
     utils.check_meilisearch_version(
-        instance, config.MEILI_CLOUD_SCRIPTS_VERSION_TAG[1:])
+        instance, config.MEILI_CLOUD_SCRIPTS_VERSION_TAG)
 except Exception as err:
+    print("   Exception: {}".format(err))
     utils.terminate_instance_and_exit(instance)
 print('   Version of meilisearch match!')
 

--- a/tools/destroy_image.py
+++ b/tools/destroy_image.py
@@ -1,0 +1,29 @@
+import sys
+import boto3
+import config
+
+ec2 = boto3.resource('ec2', config.AWS_DEFAULT_REGION)
+
+if len(sys.argv) > 1:
+    SNAPSHOT_NAME = sys.argv[1]
+else:
+    raise Exception("No snapshot name specified")
+
+MEILI_IMG = None
+images = boto3.client('ec2', config.AWS_DEFAULT_REGION).describe_images(
+    Owners=['self'])['Images']
+for img in images:
+    if img['Name'] == SNAPSHOT_NAME:
+        MEILI_IMG = boto3.resource(
+            'ec2', config.AWS_DEFAULT_REGION).Image(id=img['ImageId'])
+        print("Found image: {name} created at {creation_date}".format(
+            name=MEILI_IMG.name,
+            creation_date=MEILI_IMG.creation_date
+        ))
+        break
+
+# Deregister image
+
+print('Deregistering image...')
+MEILI_IMG.deregister()
+print('Image deregistered')

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -1,0 +1,88 @@
+import sys
+import boto3
+import utils
+import config
+
+ec2 = boto3.resource('ec2', config.AWS_DEFAULT_REGION)
+
+if len(sys.argv) > 1:
+    SNAPSHOT_NAME = sys.argv[1]
+else:
+    raise Exception("No snapshot name specified")
+
+print("Running test for image named: {name}...".format(
+    name=SNAPSHOT_NAME))
+
+# Get the image for the test
+
+MEILI_IMG = None
+images = boto3.client('ec2', config.AWS_DEFAULT_REGION).describe_images(
+    Owners=['self'])['Images']
+for img in images:
+    if img['Name'] == SNAPSHOT_NAME:
+        MEILI_IMG = boto3.resource(
+            'ec2', config.AWS_DEFAULT_REGION).Image(id=img['ImageId'])
+        print("Found image: {name} created at {creation_date}".format(
+            name=MEILI_IMG.name,
+            creation_date=MEILI_IMG.creation_date
+        ))
+        break
+
+if MEILI_IMG is None:
+    raise Exception("Couldn't find the specified image: {}".format(
+        SNAPSHOT_NAME))
+
+# Create EC2 instance from the retreived image
+
+print('Creating AWS EC2 instance from image')
+instances = ec2.create_instances(
+    ImageId=MEILI_IMG.id,
+    MinCount=1,
+    MaxCount=1,
+    InstanceType=config.INSTANCE_TYPE,
+    SecurityGroups=[
+        config.SECURITY_GROUP,
+    ]
+)
+print('   Instance created. ID: {}'.format(instances[0].id))
+
+
+# Wait for EC2 instance to be 'running'
+
+print('Waiting for AWS EC2 instance state to be "running"')
+instance = ec2.Instance(instances[0].id)
+state_code, state = utils.wait_for_instance_running(
+    instance, config.AWS_DEFAULT_REGION, timeout_seconds=600)
+print('   Instance state: {}'.format(instance.state['Name']))
+if state_code == utils.STATUS_OK:
+    print('   Instance IP: {}'.format(instance.public_ip_address))
+else:
+    print('   Error: {}. State: {}.'.format(state_code, state))
+    utils.terminate_instance_and_exit(instance)
+
+
+# # Wait for Health check after configuration is finished
+
+print('Waiting for MeiliSearch health check (may take a few minutes: config and reboot)')
+HEALTH = utils.wait_for_health_check(instance, timeout_seconds=600)
+if HEALTH == utils.STATUS_OK:
+    print('   Instance is healthy')
+else:
+    print('   Timeout waiting for health check')
+    utils.terminate_instance_and_exit(instance)
+
+# Check version
+
+print('Waiting for Version check')
+try:
+    utils.check_meilisearch_version(
+        instance, config.MEILI_CLOUD_SCRIPTS_VERSION_TAG[1:])
+except Exception as err:
+    utils.terminate_instance_and_exit(instance)
+print('   Version of meilisearch match!')
+
+# Terminate EC2 Instance
+
+print('Terminating instance...')
+instance.terminate()
+print('   Instance terminated')

--- a/tools/test_image.py
+++ b/tools/test_image.py
@@ -76,8 +76,9 @@ else:
 print('Waiting for Version check')
 try:
     utils.check_meilisearch_version(
-        instance, config.MEILI_CLOUD_SCRIPTS_VERSION_TAG[1:])
+        instance, config.MEILI_CLOUD_SCRIPTS_VERSION_TAG)
 except Exception as err:
+    print("   Exception: {}".format(err))
     utils.terminate_instance_and_exit(instance)
 print('   Version of meilisearch match!')
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -43,7 +43,7 @@ def wait_for_health_check(instance, timeout_seconds=None):
 def check_meilisearch_version(droplet, version):
     resp = requests.get(
         "http://{}/version".format(droplet.public_ip_address)).json()
-    if resp["pkgVersion"] == version:
+    if resp["pkgVersion"] in version:
         return
     raise Exception(
         "    The version of meilisearch ({}) does not match the droplet ({})".format(version, resp["pkgVersion"]))

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -40,6 +40,15 @@ def wait_for_health_check(instance, timeout_seconds=None):
     return STATUS_TIMEOUT
 
 
+def check_meilisearch_version(droplet, version):
+    resp = requests.get(
+        "http://{}/version".format(droplet.public_ip_address)).json()
+    if resp["pkgVersion"] == version:
+        return
+    raise Exception(
+        "    The version of meilisearch ({}) does not match the droplet ({})".format(version, resp["pkgVersion"]))
+
+
 def terminate_instance_and_exit(instance):
     print('   Terminating instance {}'.format(instance.id))
     instance.terminate()


### PR DESCRIPTION
- Add test_image.py to be use with the AMI name as arg
- Add destroy_image.py to be use with the AMI name as arg
- We can now optionnaly use build_image.py with an argument corresponding to the AMI name
- Add version check in build_image.py and test_image.py
- Add github action to run the test : build an image, test it and create an AMI from it, test this AMI by creating an image with it, destroy everything

⚠️ The CI needs some ENV variables to be set in github secrets to work

closes #33