### PR TITLE
Changes related to the next Meilisearch release (v0.29.1)

### DIFF
--- a/tools/build_image.py
+++ b/tools/build_image.py
@@ -18,7 +18,7 @@ else:
 
 print('Creating AWS EC2 instance')
 instances = ec2.create_instances(
-    ImageId=config.UBUNTU_BASE_IMAGE_ID,
+    ImageId=config.DEBIAN_BASE_IMAGE_ID,
     MinCount=1,
     MaxCount=1,
     InstanceType=config.INSTANCE_TYPE,

--- a/tools/config.py
+++ b/tools/config.py
@@ -3,7 +3,7 @@ import requests
 
 # Update with the Meilisearch version TAG you want to build the AMI with
 
-MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.29.0'
+MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.29.1'
 
 # Update with the AMI id that you want to publish after TESTING
 
@@ -19,8 +19,8 @@ SECURITY_GROUP = 'MarketplaceSecurityGroup'
 
 # Setup environment and settings
 
-BASE_OS_NAME = 'Ubuntu-20.04'
-UBUNTU_BASE_IMAGE_ID = 'ami-0149b2da6ceec4bb0'
+BASE_OS_NAME = 'Debian-10'
+DEBIAN_BASE_IMAGE_ID = 'ami-07d02ee1eeb0c996c'
 USER_DATA = requests.get(
     f'https://raw.githubusercontent.com/meilisearch/cloud-scripts/{MEILI_CLOUD_SCRIPTS_VERSION_TAG}/scripts/providers/aws/cloud-config.yaml'
 ).text

--- a/tools/config.py
+++ b/tools/config.py
@@ -7,11 +7,11 @@ MEILI_CLOUD_SCRIPTS_VERSION_TAG = 'v0.29.1'
 
 # Update with the AMI id that you want to publish after TESTING
 
-PUBLISH_IMAGE_ID = 'ami-0c2286be3248eecbe'
+PUBLISH_IMAGE_ID = 'ami-088265ed374119026'
 
 # Update with the AMI name that you want to unpublish/delete worldwide
 
-DELETE_IMAGE_NAME = 'Meilisearch-v0.25.2-Debian-10'
+DELETE_IMAGE_NAME = 'Meilisearch-v0.28.0-Debian-10'
 
 # Update with your own Securityt Group and Key Pair name / file
 


### PR DESCRIPTION
Due to this [issue](https://github.com/meilisearch/meilisearch/issues/2850) the AWS image was switched to ubuntu20.04.
It has been corrected since then, so the image is back on Debian [see](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.1)