### PR TITLE
Reduce the amount of CI runs from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: "weekly"
+    interval: "monthly"
     time: "04:00"
   open-pull-requests-limit: 10
   labels:


### PR DESCRIPTION
To reduce our AWS bill, I'm changing the frequency the dependabot will create PRs.